### PR TITLE
Added Nix Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 // See README.md for license details.
 
-ThisBuild / scalaVersion     := "2.13.10"
+ThisBuild / scalaVersion     := "2.13.13"
 ThisBuild / version          := "0.1.0"
 ThisBuild / organization     := "tech.rocksavage"
 ThisBuild / organizationName := "Rocksavage Technology"
 
 Test / parallelExecution := false
 
-val chiselVersion   = "5.0.0"
+val chiselVersion   = "5.3.0"
 val scalafmtVersion = "2.5.0"
 
 lazy val root = (project in file("."))
@@ -26,7 +26,7 @@ lazy val root = (project in file("."))
       "-Ymacro-annotations"
     ),
     addCompilerPlugin(
-      "org.chipsalliance" % "chisel-plugin" % "5.0.0" cross CrossVersion.full
+      "org.chipsalliance" % "chisel-plugin" % "5.3.0" cross CrossVersion.full
     )
   )
 

--- a/dev_shell.sh
+++ b/dev_shell.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+nix develop --extra-experimental-features 'nix-command flakes' -c $SHELL

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726062281,
+        "narHash": "sha256-PyFVySdGj3enKqm8RQuo4v1KLJLmNLOq2yYOHsI6e2Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e65aa8301ba4f0ab8cb98f944c14aa9da07394f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
         devShell = {
             aarch64-darwin = with nixpkgs.legacyPackages.aarch64-darwin; mkShellNoCC {
                 packages = with pkgs; [
-                    # Chisel
+                    # Chisel / firtool 1.44.0
                     (let
                         circtpkgs = import (builtins.fetchTree { 
                         type = "github"; 
@@ -15,7 +15,6 @@
                         rev = "50a7139fbd1acd4a3d4cfa695e694c529dd26f3a"; }) 
                         { inherit (pkgs) system; };
                     in circtpkgs.circt)
-
                 
                     # Scala 
                     sbt
@@ -81,7 +80,7 @@
 
             x86_64-linux = with nixpkgs.legacyPackages.x86_64-linux; mkShellNoCC {
                 packages = with pkgs; [
-                    # Chisel
+                    # Chisel / firtool 1.44.0
                     (let
                         circtpkgs = import (builtins.fetchTree { 
                         type = "github"; 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,157 @@
+{
+    description = "A flake for chisel, verilator, and OpenSTA development";
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+
+    outputs = { self, nixpkgs }: {
+        devShell = {
+            aarch64-darwin = with nixpkgs.legacyPackages.aarch64-darwin; mkShellNoCC {
+                packages = with pkgs; [
+                    # Chisel
+                    (let
+                        circtpkgs = import (builtins.fetchTree { 
+                        type = "github"; 
+                        owner = "nixos"; 
+                        repo = "nixpkgs"; 
+                        rev = "50a7139fbd1acd4a3d4cfa695e694c529dd26f3a"; }) 
+                        { inherit (pkgs) system; };
+                    in circtpkgs.circt)
+
+                
+                    # Scala 
+                    sbt
+                    scala-cli
+                    scalafmt
+
+                    # Verilator
+                    verilator
+                    ninja
+                    cmake
+
+                    # OpenSTA
+                    (pkgs.stdenv.mkDerivation {
+                        pname = "opensta";
+                        version = "2024-09-09";
+                        src =  pkgs.fetchFromGitHub {
+                            owner = "The-OpenROAD-Project";
+                            repo = "OpenSTA";
+                            rev = "20925bb00965c1199c45aca0318c2baeb4042c5a";
+                            sha256 = "sha256-gWAN+d6ioxQtxtgeq3vR+Zgq3nYRyn/u104L/xqumuY=";
+                        };
+                        buildInputs = [ 
+                            pkgs.cmake 
+                            pkgs.gcc 
+                            pkgs.tcl 
+
+                            pkgs.bison
+                            pkgs.flex
+                            pkgs.eigen
+                            pkgs.swig4
+                            pkgs.cudd
+                            pkgs.tclreadline
+                            pkgs.zlib
+                            pkgs.tcllib
+                        ];
+                        nativeBuildInputs = [ 
+                            pkgs.cmake 
+                            pkgs.tcl 
+                        ];
+                        cmakeFlags = [
+                            "-DTCL_LIBRARY=${pkgs.tcl}/lib/libtcl8.6.dylib"
+                            "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+                        ];
+                        installPhase = ''
+                            mkdir -p ${placeholder "out"}
+                            make install
+                        '';
+                    })
+                    yosys
+                    gtkwave
+                    verilog
+
+                    # LaTeX
+                    texliveFull
+
+                    firefox
+                ];
+                shellHook = ''
+                    export CXX=/usr/bin/c++
+                    export CC=/usr/bin/cc
+                '';
+            };
+
+            x86_64-linux = with nixpkgs.legacyPackages.x86_64-linux; mkShellNoCC {
+                packages = with pkgs; [
+                    # Chisel
+                    (let
+                        circtpkgs = import (builtins.fetchTree { 
+                        type = "github"; 
+                        owner = "nixos"; 
+                        repo = "nixpkgs"; 
+                        rev = "50a7139fbd1acd4a3d4cfa695e694c529dd26f3a"; }) 
+                        { inherit (pkgs) system; };
+                    in circtpkgs.circt)
+                                    
+                    # Scala 
+                    sbt
+                    scala-cli
+
+                    # Verilator
+                    verilator
+                    ninja
+                    cmake
+
+                    # OpenSTA
+                    (pkgs.stdenv.mkDerivation {
+                        pname = "opensta";
+                        version = "2024-09-09";
+                        src =  pkgs.fetchFromGitHub {
+                            owner = "The-OpenROAD-Project";
+                            repo = "OpenSTA";
+                            rev = "20925bb00965c1199c45aca0318c2baeb4042c5a";
+                            sha256 = "sha256-gWAN+d6ioxQtxtgeq3vR+Zgq3nYRyn/u104L/xqumuY=";
+                        };
+                        buildInputs = [ 
+                            pkgs.cmake 
+                            pkgs.gcc 
+                            pkgs.tcl 
+
+                            pkgs.bison
+                            pkgs.flex
+                            pkgs.eigen
+                            pkgs.swig4
+                            pkgs.cudd
+                            pkgs.tclreadline
+                            pkgs.zlib
+                            pkgs.tcllib
+                        ];
+                        nativeBuildInputs = [ 
+                            pkgs.cmake 
+                            pkgs.tcl 
+                        ];
+                        cmakeFlags = [
+                            "-DTCL_LIBRARY=${pkgs.tcl}/lib/libtcl8.6.so"
+                            "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+                        ];
+                        installPhase = ''
+                            mkdir -p ${placeholder "out"}
+                            make install
+                        '';
+                    })
+                    yosys
+                    gtkwave
+                    verilog
+
+                     # LaTeX
+                    texliveFull
+
+                    firefox
+                    gcc
+                ];
+                shellHook = ''
+                    export CHISEL_FIRTOOL_PATH="${pkgs.circt}/bin"
+                '';
+            };
+        };
+    };
+}
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.11")


### PR DESCRIPTION
1. Added flake.nix, flake.lock, and dev_shell.sh to install development dependencies locally & not system-wide
2. Minor version changes to get everything compatible together
    1. Changed scala 2.13.10 -> 2.13.13
    2. Changed chisel 5.0.0 -> 5.3.0 (needed this to get sbt-scoverage working, would not work on 5.0.0)
    3. Changed sbt-scoverage 2.0.5 -> 2.0.11